### PR TITLE
Shared Application State

### DIFF
--- a/telemetry/server/src/main.rs
+++ b/telemetry/server/src/main.rs
@@ -1,16 +1,33 @@
 use axum::Router;
 mod openmct;
 use dotenv::dotenv;
+use influxdb2::Client;
+
+#[derive(Clone)]
+pub struct TelemetryServerState {
+    influxdb_client: influxdb2::Client,
+}
 
 #[tokio::main]
 async fn main() {
     dotenv().ok();
 
-    let app = Router::new().nest("/openmct", openmct::routes::get_routes());
+    let host = std::env::var("INFLUXDB_HOST").unwrap();
+    let org = std::env::var("INFLUXDB_ORG").unwrap();
+    let token = std::env::var("INFLUXDB_TOKEN").unwrap();
+    let client = Client::new(host, org, token);
+    let state = TelemetryServerState {
+        influxdb_client: client,
+    };
+
+    let app = Router::new()
+        .nest("/openmct", openmct::routes::get_routes())
+        .with_state(state);
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:4000")
         .await
         .unwrap();
+
     println!("listening on {}", listener.local_addr().unwrap());
     axum::serve(listener, app).await.unwrap();
 }

--- a/telemetry/server/src/openmct/data.rs
+++ b/telemetry/server/src/openmct/data.rs
@@ -1,7 +1,8 @@
+use crate::TelemetryServerState;
 use axum::Router;
 
 mod historical;
 
-pub fn get_routes() -> Router {
+pub fn get_routes() -> Router<TelemetryServerState> {
     Router::new().nest("/historical", historical::get_routes())
 }

--- a/telemetry/server/src/openmct/data/historical.rs
+++ b/telemetry/server/src/openmct/data/historical.rs
@@ -18,7 +18,7 @@ pub fn get_routes() -> Router<TelemetryServerState> {
 
 #[derive(Debug, FromDataPoint, Serialize)]
 pub struct InfluxHistoricalReading {
-    measurement_key: String,
+    measurementKey: String,
     _time: DateTime<FixedOffset>,
     value: f64,
 }
@@ -34,7 +34,7 @@ pub struct HistoricalReading {
 impl Default for InfluxHistoricalReading {
     fn default() -> Self {
         Self {
-            measurement_key: "".to_string(),
+            measurementKey: "".to_string(),
             _time: DateTime::parse_from_rfc3339("1970-01-01T00:00:00Z").unwrap(),
             value: 0.0,
         }
@@ -84,7 +84,7 @@ async fn get_historical_reading(
             let res = Json(
                 res.into_iter()
                     .map(|reading| HistoricalReading {
-                        id: reading.measurement_key,
+                        id: reading.measurementKey,
                         timestamp: reading._time.timestamp_millis(),
                         value: reading.value,
                     })

--- a/telemetry/server/src/openmct/data/historical.rs
+++ b/telemetry/server/src/openmct/data/historical.rs
@@ -52,7 +52,9 @@ struct TimespanQuery {
 async fn get_historical_reading(
     Path((pod, measurement_key)): Path<(String, String)>,
     Query(query): Query<TimespanQuery>,
-    State(state): State<TelemetryServerState>,
+    State(TelemetryServerState {
+        influxdb_client, ..
+    }): State<TelemetryServerState>,
 ) -> Result<Json<Vec<HistoricalReading>>, (StatusCode, String)> {
     let telemetry_bucket = std::env::var("INFLUXDB_TELEMETRY_BUCKET").unwrap();
 
@@ -73,8 +75,7 @@ async fn get_historical_reading(
     );
 
     let query = InfluxQuery::new(qs.to_string());
-    let influx_res = state
-        .influxdb_client
+    let influx_res = influxdb_client
         .query::<InfluxHistoricalReading>(Some(query))
         .await;
 

--- a/telemetry/server/src/openmct/data/historical.rs
+++ b/telemetry/server/src/openmct/data/historical.rs
@@ -1,13 +1,15 @@
-use axum::extract::Query;
+use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::{extract::Path, routing::get, Json, Router};
 use axum_macros::debug_handler;
 use chrono::{DateTime, FixedOffset};
 use influxdb2::models::Query as InfluxQuery;
-use influxdb2::{Client, FromDataPoint};
+use influxdb2::FromDataPoint;
 use serde::Serialize;
 
-pub fn get_routes() -> Router {
+use crate::TelemetryServerState;
+
+pub fn get_routes() -> Router<TelemetryServerState> {
     Router::new().route(
         "/pods/:pod/measurements/:measurement_key",
         get(get_historical_reading),
@@ -16,7 +18,7 @@ pub fn get_routes() -> Router {
 
 #[derive(Debug, FromDataPoint, Serialize)]
 pub struct InfluxHistoricalReading {
-    measurementKey: String,
+    measurement_key: String,
     _time: DateTime<FixedOffset>,
     value: f64,
 }
@@ -32,7 +34,7 @@ pub struct HistoricalReading {
 impl Default for InfluxHistoricalReading {
     fn default() -> Self {
         Self {
-            measurementKey: "".to_string(),
+            measurement_key: "".to_string(),
             _time: DateTime::parse_from_rfc3339("1970-01-01T00:00:00Z").unwrap(),
             value: 0.0,
         }
@@ -50,12 +52,9 @@ struct TimespanQuery {
 async fn get_historical_reading(
     Path((pod, measurement_key)): Path<(String, String)>,
     Query(query): Query<TimespanQuery>,
+    State(state): State<TelemetryServerState>,
 ) -> Result<Json<Vec<HistoricalReading>>, (StatusCode, String)> {
-    let host = std::env::var("INFLUXDB_HOST").unwrap();
-    let org = std::env::var("INFLUXDB_ORG").unwrap();
-    let token = std::env::var("INFLUXDB_TOKEN").unwrap();
     let telemetry_bucket = std::env::var("INFLUXDB_TELEMETRY_BUCKET").unwrap();
-    let client = Client::new(host, org, token);
 
     let qs = format!(
         "from(bucket: \"{}\")
@@ -74,14 +73,17 @@ async fn get_historical_reading(
     );
 
     let query = InfluxQuery::new(qs.to_string());
-    let influx_res = client.query::<InfluxHistoricalReading>(Some(query)).await;
+    let influx_res = state
+        .influxdb_client
+        .query::<InfluxHistoricalReading>(Some(query))
+        .await;
 
     match influx_res {
         Ok(res) => {
             let res = Json(
                 res.into_iter()
                     .map(|reading| HistoricalReading {
-                        id: reading.measurementKey,
+                        id: reading.measurement_key,
                         timestamp: reading._time.timestamp_millis(),
                         value: reading.value,
                     })

--- a/telemetry/server/src/openmct/dictionary.rs
+++ b/telemetry/server/src/openmct/dictionary.rs
@@ -1,6 +1,8 @@
 use axum::{extract::Path, routing::get, Json, Router};
 
-pub fn get_routes() -> Router {
+use crate::TelemetryServerState;
+
+pub fn get_routes() -> Router<TelemetryServerState> {
     Router::new()
         .route("/pods", get(pods))
         .route("/pods/:pod", get(get_pod))

--- a/telemetry/server/src/openmct/routes.rs
+++ b/telemetry/server/src/openmct/routes.rs
@@ -1,11 +1,14 @@
 use axum::{routing::get, Json, Router};
 
-use crate::openmct::{
-    data, dictionary,
-    object_types::{OpenMctObject, OPEN_MCT_OBJECT_TYPES},
+use crate::{
+    openmct::{
+        data, dictionary,
+        object_types::{OpenMctObject, OPEN_MCT_OBJECT_TYPES},
+    },
+    TelemetryServerState,
 };
 
-pub fn get_routes() -> Router {
+pub fn get_routes() -> Router<TelemetryServerState> {
     Router::new()
         .route("/", get(handler))
         .route("/object-types", get(get_object_types))


### PR DESCRIPTION
:warning: This pr hasn't been tested as I don't have all the infra setup.

- Use with_state to share the influxdb client over all routes that need it.
- Correct minor snakecase warning in `InfluxHistoricalReading` 