### PR TITLE
INFRA - Add STM32H743ZI board to CI, add caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,6 @@ jobs:
       - run: cargo build --verbose
         working-directory: boards/stm32l476rg
       - run: cargo build --verbose
+        working-directory: boards/stm32h743zi
+      - run: cargo build --verbose
         working-directory: boards/stm32f767zi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,18 @@ jobs:
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: cargo build --verbose
       - run: cargo test --verbose
+
+  build_boards:
+    name: Cargo Build (Boards)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        board:
+          - stm32l476rg
+          - stm32h743zi
+          - stm32f767zi
+    steps:
+      - uses: actions/checkout@v4
       - run: rustup target add thumbv7em-none-eabihf
       - run: cargo build --verbose
-        working-directory: boards/stm32l476rg
-      - run: cargo build --verbose
-        working-directory: boards/stm32h743zi
-      - run: cargo build --verbose
-        working-directory: boards/stm32f767zi
+        working-directory: boards/${{ matrix.board }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - uses: Swatinem/rust-cache@v2
       - run: cargo build --verbose
       - run: cargo test --verbose
 
@@ -35,5 +36,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup target add thumbv7em-none-eabihf
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-directories: |
+            ~/.cargo
+            ~/.rustup
+            boards/${{ matrix.board }}/target
       - run: cargo build --verbose
         working-directory: boards/${{ matrix.board }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,5 +37,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: rustup target add thumbv7em-none-eabihf
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.board }}
       - run: cargo build --verbose
         working-directory: boards/${{ matrix.board }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - run: cargo test --verbose
 
   build_boards:
-    name: Cargo Build (Boards)
+    name: Cargo Build (boards)
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,5 @@ jobs:
       - uses: actions/checkout@v4
       - run: rustup target add thumbv7em-none-eabihf
       - uses: Swatinem/rust-cache@v2
-        with:
-          cache-directories: |
-            ~/.cargo
-            ~/.rustup
-            boards/${{ matrix.board }}/target
       - run: cargo build --verbose
         working-directory: boards/${{ matrix.board }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,8 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run rustfmt
-        run: cargo fmt --all -- --check
+      - run: cargo fmt --all -- --check
+      - run: cargo fmt --manifest-path boards/stm32l476rg/Cargo.toml -- --check
+      - run: cargo fmt --manifest-path boards/stm32f767zi/Cargo.toml -- --check
+      - run: cargo fmt --manifest-path boards/stm32f429zi/Cargo.toml -- --check
 
   typos:
     name: Spell check with typos

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,9 +17,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: cargo fmt --all -- --check
-      - run: cargo fmt --manifest-path boards/stm32l476rg/Cargo.toml -- --check
-      - run: cargo fmt --manifest-path boards/stm32h743zi/Cargo.toml -- --check
-      - run: cargo fmt --manifest-path boards/stm32f767zi/Cargo.toml -- --check
+
+  rust-fmt-boards:
+    name: Run rustfmt (boards)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        board:
+          - stm32l476rg
+          - stm32h743zi
+          - stm32f767zi
+    steps:
+      - uses: actions/checkout@v4
+      - run: cargo fmt --manifest-path boards/${{ matrix.board }}/Cargo.toml -- --check
 
   typos:
     name: Spell check with typos

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,8 +18,8 @@ jobs:
       - uses: actions/checkout@v4
       - run: cargo fmt --all -- --check
       - run: cargo fmt --manifest-path boards/stm32l476rg/Cargo.toml -- --check
+      - run: cargo fmt --manifest-path boards/stm32h743zi/Cargo.toml -- --check
       - run: cargo fmt --manifest-path boards/stm32f767zi/Cargo.toml -- --check
-      - run: cargo fmt --manifest-path boards/stm32f429zi/Cargo.toml -- --check
 
   typos:
     name: Spell check with typos

--- a/boards/stm32h743zi/src/tasks/heartbeat.rs
+++ b/boards/stm32h743zi/src/tasks/heartbeat.rs
@@ -10,13 +10,13 @@ use {defmt_rtt as _, panic_probe as _};
 #[embassy_executor::task]
 pub async fn heartbeat() {
     loop {
+        debug!("Sending heartbeat...");
         SEND_CHANNEL
             .send(MqttMessage {
                 topic: MqttTopics::to_string(&MqttTopics::Heartbeat),
                 payload: String::<512>::from_str("").unwrap(),
             })
             .await;
-        debug!("Heartbeat sent");
         Timer::after(Duration::from_secs(1)).await;
     }
 }


### PR DESCRIPTION
**Changes:**
- Adds a missing build step for the STM32H743ZI board
- Made board builds run concurrently (no longer tested on `stable`, `beta`, `nightly` keychain though) (this could be added though?)
- Formatter runs on board code now lol
- Adds caching using [rust-cache](https://github.com/Swatinem/rust-cache) to speed up builds
  - Doesn't seem to cache some Embassy-related dependencies on the boards, but still saves around 30s

**To think about:**
- Should we be testing across Linux, Windows and MacOS?