### PR TITLE
SNS - I2C Macro

### DIFF
--- a/lib/core/src/format_string.rs
+++ b/lib/core/src/format_string.rs
@@ -20,7 +20,7 @@ impl<'a> FormatString<'a> {
     }
 }
 
-impl<'a> fmt::Write for FormatString<'a> {
+impl fmt::Write for FormatString<'_> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         if self.used > self.buffer.len() {
             return Err(fmt::Error);

--- a/lib/io/hyped_i2c/src/lib.rs
+++ b/lib/io/hyped_i2c/src/lib.rs
@@ -26,6 +26,8 @@ pub trait HypedI2c {
 }
 
 #[macro_export]
+/// Macro to write a byte to a register on an I2C device or return an error.
+/// Does nothing if the write is successful, otherwise returns the error type specified.
 macro_rules! i2c_write_or_err {
     ($i2c:expr, $device_address:expr, $register_address:expr, $data:expr, $err_type:ty) => {
         match $i2c.write_byte_to_register($device_address, $register_address, $data) {

--- a/lib/io/hyped_i2c/src/lib.rs
+++ b/lib/io/hyped_i2c/src/lib.rs
@@ -25,6 +25,16 @@ pub trait HypedI2c {
     ) -> Result<(), I2cError>;
 }
 
+#[macro_export]
+macro_rules! i2c_write_or_err {
+    ($i2c:expr, $device_address:expr, $register_address:expr, $data:expr, $err_type:ty) => {
+        match $i2c.write_byte_to_register($device_address, $register_address, $data) {
+            Ok(_) => (),
+            Err(e) => return Err(<$err_type>::I2cError(e)),
+        }
+    };
+}
+
 pub mod mock_i2c {
     use core::cell::RefCell;
     use embassy_sync::blocking_mutex::{raw::CriticalSectionRawMutex, Mutex};

--- a/lib/sensors/src/temperature.rs
+++ b/lib/sensors/src/temperature.rs
@@ -32,21 +32,13 @@ impl<'a, T: HypedI2c> Temperature<'a, T> {
     /// Read the temperature from the sensor and return it as a floating point value in degrees Celsius
     pub fn read(&mut self) -> Option<f32> {
         // Read the high and low bytes of the temperature and combine them to get the temperature
-        let temperature_high_byte =
-            match self.i2c.read_byte(self.device_address, STTS22H_DATA_TEMP_H) {
-                Some(byte) => byte,
-                None => {
-                    return None;
-                }
-            };
+        let temperature_high_byte = self
+            .i2c
+            .read_byte(self.device_address, STTS22H_DATA_TEMP_H)?;
+        let temperature_low_byte = self
+            .i2c
+            .read_byte(self.device_address, STTS22H_DATA_TEMP_L)?;
 
-        let temperature_low_byte =
-            match self.i2c.read_byte(self.device_address, STTS22H_DATA_TEMP_L) {
-                Some(byte) => byte,
-                None => {
-                    return None;
-                }
-            };
         let combined: f32 =
             ((temperature_high_byte as u16) << 8 | temperature_low_byte as u16) as f32;
 


### PR DESCRIPTION
Creates a macro for writing to a value to an I2C address or returning an error (seems to be a very common operation requiring several lines of code).