### PR TITLE
SNS - Split CAN IO into Rx and Tx

### DIFF
--- a/boards/stm32f767zi/src/bin/can_io_recv_test.rs
+++ b/boards/stm32f767zi/src/bin/can_io_recv_test.rs
@@ -13,7 +13,6 @@ use embassy_stm32::can::{
 use embassy_stm32::peripherals::CAN1;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_sync::blocking_mutex::Mutex;
-use embassy_time::Timer;
 use hyped_boards_stm32f767zi::io::Stm32f767ziCan;
 use hyped_can::HypedCan;
 use static_cell::StaticCell;

--- a/boards/stm32f767zi/src/io.rs
+++ b/boards/stm32f767zi/src/io.rs
@@ -1,16 +1,21 @@
 use core::cell::RefCell;
-use embassy_stm32::adc::{Adc, AnyAdcChannel, Instance};
-use embassy_stm32::can::{
-    enums::{BusError, FrameCreateError, TryReadError},
-    frame, Can, ExtendedId, Frame, Id, StandardId, TryWriteError,
+
+use embassy_stm32::{
+    adc::{Adc, AnyAdcChannel, Instance},
+    can::{
+        enums::{BusError, FrameCreateError, TryReadError},
+        frame, Can, CanRx, CanTx, ExtendedId, Frame, Id, StandardId, TryWriteError,
+    },
+    gpio::{Input, Output},
+    i2c::I2c,
+    mode::Blocking,
 };
-use embassy_stm32::gpio::{Input, Output};
-use embassy_stm32::{i2c::I2c, mode::Blocking};
 use embassy_sync::blocking_mutex::{raw::NoopRawMutex, Mutex};
+
 use hyped_adc::HypedAdc;
 use hyped_adc_derive::HypedAdc;
-use hyped_can::{CanError, HypedCan, HypedCanFrame, HypedEnvelope};
-use hyped_can_derive::HypedCan;
+use hyped_can::{CanError, HypedCan, HypedCanFrame, HypedCanRx, HypedCanTx, HypedEnvelope};
+use hyped_can_derive::{HypedCan, HypedCanRx, HypedCanTx};
 use hyped_gpio::{HypedGpioInputPin, HypedGpioOutputPin};
 use hyped_gpio_derive::{HypedGpioInputPin, HypedGpioOutputPin};
 use hyped_i2c::{HypedI2c, I2cError};
@@ -40,4 +45,14 @@ pub struct Stm32f767ziI2c<'d> {
 #[derive(HypedCan)]
 pub struct Stm32f767ziCan<'d> {
     can: &'d Mutex<NoopRawMutex, RefCell<&'d mut Can<'static>>>,
+}
+
+#[derive(HypedCanRx)]
+pub struct Stm32f767ziCanRx<'d> {
+    can: &'d Mutex<NoopRawMutex, RefCell<&'d mut CanRx<'static>>>,
+}
+
+#[derive(HypedCanTx)]
+pub struct Stm32f767ziCanTx<'d> {
+    can: &'d Mutex<NoopRawMutex, RefCell<&'d mut CanTx<'static>>>,
 }

--- a/boards/stm32l476rg/Cargo.lock
+++ b/boards/stm32l476rg/Cargo.lock
@@ -630,8 +630,8 @@ dependencies = [
 name = "hyped_adc"
 version = "0.1.0"
 dependencies = [
- "embassy-sync 0.6.2",
  "defmt",
+ "embassy-sync 0.6.2",
  "heapless",
 ]
 
@@ -662,6 +662,8 @@ dependencies = [
  "embedded-storage",
  "hyped_adc",
  "hyped_adc_derive",
+ "hyped_can",
+ "hyped_can_derive",
  "hyped_control",
  "hyped_core",
  "hyped_gpio",
@@ -672,6 +674,24 @@ dependencies = [
  "panic-probe",
  "rand_core",
  "static_cell",
+]
+
+[[package]]
+name = "hyped_can"
+version = "0.1.0"
+dependencies = [
+ "defmt",
+ "embassy-sync 0.6.0",
+ "embassy-time",
+ "heapless",
+]
+
+[[package]]
+name = "hyped_can_derive"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/boards/stm32l476rg/Cargo.toml
+++ b/boards/stm32l476rg/Cargo.toml
@@ -29,6 +29,8 @@ hyped_control = { path = "../../lib/control" }
 
 hyped_adc = { path = "../../lib/io/hyped_adc" }
 hyped_adc_derive = { path = "../../lib/io/hyped_adc/hyped_adc_derive" }
+hyped_can = { path = "../../lib/io/hyped_can" }
+hyped_can_derive = { path = "../../lib/io/hyped_can/hyped_can_derive" }
 hyped_i2c = { path = "../../lib/io/hyped_i2c" }
 hyped_i2c_derive = { path = "../../lib/io/hyped_i2c/hyped_i2c_derive" }
 hyped_gpio = { path = "../../lib/io/hyped_gpio" }

--- a/boards/stm32l476rg/src/io.rs
+++ b/boards/stm32l476rg/src/io.rs
@@ -1,13 +1,21 @@
 use core::cell::RefCell;
 
-use embassy_stm32::adc::{Adc, AnyAdcChannel, Instance};
-use embassy_stm32::gpio::{Input, Output};
-use embassy_stm32::{i2c::I2c, mode::Blocking};
-use embassy_sync::blocking_mutex::raw::NoopRawMutex;
-use embassy_sync::blocking_mutex::Mutex;
+use embassy_stm32::{
+    adc::{Adc, AnyAdcChannel, Instance},
+    can::{
+        enums::{BusError, FrameCreateError, TryReadError},
+        frame, Can, CanRx, CanTx, ExtendedId, Frame, Id, StandardId, TryWriteError,
+    },
+    gpio::{Input, Output},
+    i2c::I2c,
+    mode::Blocking,
+};
+use embassy_sync::blocking_mutex::{raw::NoopRawMutex, Mutex};
 
 use hyped_adc::HypedAdc;
 use hyped_adc_derive::HypedAdc;
+use hyped_can::{CanError, HypedCan, HypedCanFrame, HypedCanRx, HypedCanTx, HypedEnvelope};
+use hyped_can_derive::{HypedCan, HypedCanRx, HypedCanTx};
 use hyped_gpio::{HypedGpioInputPin, HypedGpioOutputPin};
 use hyped_gpio_derive::{HypedGpioInputPin, HypedGpioOutputPin};
 use hyped_i2c::{HypedI2c, I2cError};
@@ -32,4 +40,19 @@ pub struct Stm32l476rgGpioOutput {
 #[derive(HypedI2c)]
 pub struct Stm32l476rgI2c<'d> {
     i2c: &'d Mutex<NoopRawMutex, RefCell<I2c<'static, Blocking>>>,
+}
+
+#[derive(HypedCan)]
+pub struct Stm32l476rgCan<'d> {
+    can: &'d Mutex<NoopRawMutex, RefCell<&'d mut Can<'static>>>,
+}
+
+#[derive(HypedCanRx)]
+pub struct Stm32l476rgCanRx<'d> {
+    can: &'d Mutex<NoopRawMutex, RefCell<&'d mut CanRx<'static>>>,
+}
+
+#[derive(HypedCanTx)]
+pub struct Stm32l476rgCanTx<'d> {
+    can: &'d Mutex<NoopRawMutex, RefCell<&'d mut CanTx<'static>>>,
 }

--- a/lib/io/hyped_can/hyped_can_derive/src/lib.rs
+++ b/lib/io/hyped_can/hyped_can_derive/src/lib.rs
@@ -57,7 +57,6 @@ fn impl_hyped_can(ast: &syn::DeriveInput) -> TokenStream {
                     Id::Extended(ExtendedId::new(frame.can_id).unwrap())
                 };
 
-
                 let frame_header = frame::Header::new(id, frame.data.len() as u8, false);
 
                 let frame = Frame::new(frame_header, &frame.data);
@@ -84,7 +83,112 @@ fn impl_hyped_can(ast: &syn::DeriveInput) -> TokenStream {
                 Self { can }
             }
         }
+    };
+    gen.into()
+}
 
+#[proc_macro_derive(HypedCanRx)]
+pub fn hyped_can_rx_derive(input: TokenStream) -> TokenStream {
+    let ast = syn::parse(input).unwrap();
+    impl_hyped_can_rx(&ast)
+}
+
+fn impl_hyped_can_rx(ast: &syn::DeriveInput) -> TokenStream {
+    let name = &ast.ident;
+    let generics: &Generics = &ast.generics;
+    let (impl_generics, ty_generics, _) = generics.split_for_impl();
+    let gen = quote! {
+        impl #impl_generics HypedCanRx for #name #ty_generics {
+            fn read_frame(&mut self) -> Result<HypedEnvelope, CanError> {
+                let result = self.can.lock(|can| can.borrow_mut().try_read());
+                match result {
+                    Ok(envelope) => {
+                        let id = envelope.frame.id();
+                        let can_id = match id {
+                            Id::Standard(id) => id.as_raw() as u32, // 11-bit ID
+                            Id::Extended(id) => id.as_raw(),        // 29-bit ID
+                        };
+
+                        let mut data = [0u8; 8];
+                        data.copy_from_slice(envelope.frame.data());
+
+                        Ok(HypedEnvelope {
+                            frame: HypedCanFrame { can_id, data },
+                            ts: envelope.ts,
+                        })
+                    }
+                    Err(TryReadError::BusError(e)) => Err(match e {
+                        BusError::Stuff => CanError::Stuff,
+                        BusError::Form => CanError::Form,
+                        BusError::Acknowledge => CanError::Acknowledge,
+                        BusError::BitRecessive => CanError::BitRecessive,
+                        BusError::BitDominant => CanError::BitDominant,
+                        BusError::Crc => CanError::Crc,
+                        BusError::Software => CanError::Software,
+                        BusError::BusOff => CanError::BusOff,
+                        BusError::BusPassive => CanError::BusPassive,
+                        BusError::BusWarning => CanError::BusWarning,
+                    }),
+                    Err(TryReadError::Empty) => Err(CanError::Empty),
+                }
+            }
+        }
+
+        impl #impl_generics #name #ty_generics {
+            pub fn new(can: &'d Mutex<NoopRawMutex, RefCell<&'d mut CanRx<'static>>>) -> Self {
+                Self { can }
+            }
+        }
+    };
+    gen.into()
+}
+
+#[proc_macro_derive(HypedCanTx)]
+pub fn hyped_can_tx_derive(input: TokenStream) -> TokenStream {
+    let ast = syn::parse(input).unwrap();
+    impl_hyped_can_tx(&ast)
+}
+
+fn impl_hyped_can_tx(ast: &syn::DeriveInput) -> TokenStream {
+    let name = &ast.ident;
+    let generics: &Generics = &ast.generics;
+    let (impl_generics, ty_generics, _) = generics.split_for_impl();
+    let gen = quote! {
+        impl #impl_generics HypedCanTx for #name #ty_generics {
+            fn write_frame(&mut self, frame: &HypedCanFrame) -> Result<(), CanError> {
+                let id = if frame.can_id <= 0x7FF {
+                    Id::Standard(StandardId::new(frame.can_id as u16).unwrap())
+                } else {
+                    Id::Extended(ExtendedId::new(frame.can_id).unwrap())
+                };
+
+
+                let frame_header = frame::Header::new(id, frame.data.len() as u8, false);
+
+                let frame = Frame::new(frame_header, &frame.data);
+
+                match frame {
+                    Ok(frame) => {
+                        let result = self.can.lock(|can| can.borrow_mut().try_write(&frame));
+                        match result {
+                            Ok(_) => Ok(()),
+                            Err(TryWriteError::Full) => Err(CanError::Full),
+                        }
+                    }
+                    Err(e) => Err(match e {
+                        FrameCreateError::NotEnoughData => CanError::NotEnoughData,
+                        FrameCreateError::InvalidDataLength => CanError::InvalidDataLength,
+                        FrameCreateError::InvalidCanId => CanError::InvalidCanId,
+                    }),
+                }
+            }
+        }
+
+        impl #impl_generics #name #ty_generics {
+            pub fn new(can: &'d Mutex<NoopRawMutex, RefCell<&'d mut CanTx<'static>>>) -> Self {
+                Self { can }
+            }
+        }
     };
     gen.into()
 }

--- a/lib/io/hyped_can/src/lib.rs
+++ b/lib/io/hyped_can/src/lib.rs
@@ -47,12 +47,22 @@ pub struct HypedEnvelope {
     pub frame: HypedCanFrame,
 }
 
-/// CAN trait used to abstract the CAN operations
 pub trait HypedCan {
     /// Attempts to read a CAN frame without blocking.
     ///
     /// Returns [Err(TryReadError::Empty)] if there are no frames in the rx queue.
     fn read_frame(&mut self) -> Result<HypedEnvelope, CanError>;
+    /// /// Attempts to transmit a frame without blocking.
+    ///
+    /// Returns [Err(CanError::Full)] if the frame can not be queued for transmission now.
+    ///
+    /// The frame will only be accepted if there is no frame with the same priority already queued. This is done
+    /// to work around a hardware limitation that could lead to out-of-order delivery of frames with the same priority.
+    fn write_frame(&mut self, frame: &HypedCanFrame) -> Result<(), CanError>;
+}
+
+/// A CAN interface for sending CAN frames
+pub trait HypedCanTx {
     /// Attempts to transmit a frame without blocking.
     ///
     /// Returns [Err(CanError::Full)] if the frame can not be queued for transmission now.
@@ -62,12 +72,23 @@ pub trait HypedCan {
     fn write_frame(&mut self, frame: &HypedCanFrame) -> Result<(), CanError>;
 }
 
+/// A CAN interface for receiving CAN frames
+///
+/// (Will probably not be used because we'll be putting received CAN frames into a channel
+/// and calling a callback function to handle them.)
+pub trait HypedCanRx {
+    /// /// Attempts to read a CAN frame without blocking.
+    ///
+    /// Returns [Err(TryReadError::Empty)] if there are no frames in the rx queue.
+    fn read_frame(&mut self) -> Result<HypedEnvelope, CanError>;
+}
+
 pub mod mock_can {
     use core::cell::RefCell;
     use embassy_sync::blocking_mutex::{raw::CriticalSectionRawMutex, Mutex};
     use heapless::Deque;
 
-    use crate::HypedCanFrame;
+    use crate::{HypedCan, HypedCanFrame};
 
     /// A fixed-size map of CAN frames
     type CanValues = Deque<HypedCanFrame, 8>;
@@ -84,7 +105,7 @@ pub mod mock_can {
         fail_write: &'a Mutex<CriticalSectionRawMutex, bool>,
     }
 
-    impl crate::HypedCan for MockCan<'_> {
+    impl HypedCan for MockCan<'_> {
         fn read_frame(&mut self) -> Result<super::HypedEnvelope, super::CanError> {
             if self.fail_read.lock(|fail_read| *fail_read) {
                 return Err(super::CanError::Unknown);
@@ -136,6 +157,93 @@ pub mod mock_can {
         /// Get the values that have been sent over the CAN bus
         pub fn get_can_frames(&self) -> &CanValues {
             &self.frames_sent
+        }
+    }
+
+    /// A mock CAN instance which can be used for testing
+    pub struct MockCanRx<'a> {
+        /// Values that have been read from the CAN bus
+        frames_to_read: &'a Mutex<CriticalSectionRawMutex, RefCell<CanValues>>,
+        /// Whether to fail reading frames
+        fail_read: &'a Mutex<CriticalSectionRawMutex, bool>,
+    }
+
+    pub struct MockCanTx<'a> {
+        /// Values that have been sent over the CAN bus
+        frames_sent: CanValues,
+        /// Whether to fail writing frames
+        fail_write: &'a Mutex<CriticalSectionRawMutex, bool>,
+    }
+
+    impl crate::HypedCanRx for MockCanRx<'_> {
+        fn read_frame(&mut self) -> Result<super::HypedEnvelope, super::CanError> {
+            if self.fail_read.lock(|fail_read| *fail_read) {
+                return Err(super::CanError::Unknown);
+            }
+            self.frames_to_read.lock(|frames_to_read| {
+                match frames_to_read.borrow_mut().pop_front() {
+                    Some(frame) => Ok(super::HypedEnvelope {
+                        ts: embassy_time::Instant::now(),
+                        frame,
+                    }),
+                    None => Err(super::CanError::Empty),
+                }
+            })
+        }
+    }
+
+    impl crate::HypedCanTx for MockCanTx<'_> {
+        fn write_frame(&mut self, frame: &super::HypedCanFrame) -> Result<(), super::CanError> {
+            if self.fail_write.lock(|fail_write| *fail_write) {
+                return Err(super::CanError::Unknown);
+            }
+            match self.frames_sent.push_front(*frame) {
+                Ok(_) => Ok(()),
+                Err(_) => Err(super::CanError::Unknown),
+            }
+        }
+    }
+
+    impl MockCanRx<'_> {
+        pub fn new(
+            frames_to_read: &'static Mutex<CriticalSectionRawMutex, RefCell<CanValues>>,
+        ) -> Self {
+            static FAIL_READ: Mutex<CriticalSectionRawMutex, bool> = Mutex::new(false);
+            MockCanRx::new_with_failure(frames_to_read, &FAIL_READ)
+        }
+
+        pub fn new_with_failure(
+            frames_to_read: &'static Mutex<CriticalSectionRawMutex, RefCell<CanValues>>,
+            fail_read: &'static Mutex<CriticalSectionRawMutex, bool>,
+        ) -> Self {
+            MockCanRx {
+                frames_to_read,
+                fail_read,
+            }
+        }
+    }
+
+    impl MockCanTx<'_> {
+        pub fn new() -> Self {
+            static FAIL_WRITE: Mutex<CriticalSectionRawMutex, bool> = Mutex::new(false);
+            MockCanTx::new_with_failure(&FAIL_WRITE)
+        }
+
+        pub fn new_with_failure(fail_write: &'static Mutex<CriticalSectionRawMutex, bool>) -> Self {
+            MockCanTx {
+                frames_sent: CanValues::new(),
+                fail_write,
+            }
+        }
+
+        pub fn frames_sent(&self) -> &CanValues {
+            &self.frames_sent
+        }
+    }
+
+    impl Default for MockCanTx<'_> {
+        fn default() -> Self {
+            MockCanTx::new()
         }
     }
 }


### PR DESCRIPTION
Splits `HypedCan` into `HypedCanRx` and `HypedCanTx` so that we can have a sensor (e.g. the IMD) just take in a CAN sender so that a separate task can be constantly checking for new CAN messages using a receiver to run a callback.