### PR TITLE
SNS - Fix `Watch` issue (set sensor update frequencies)

### DIFF
--- a/boards/stm32f767zi/src/bin/temperature_test.rs
+++ b/boards/stm32f767zi/src/bin/temperature_test.rs
@@ -37,9 +37,7 @@ async fn main(spawner: Spawner) -> ! {
     let temp_reading_sender = TEMP_READING.sender();
     let mut temp_reading_receiver = TEMP_READING.receiver().unwrap();
 
-    spawner
-        .spawn(read_temperature(i2c_bus, temp_reading_sender))
-        .unwrap();
+    spawner.must_spawn(read_temperature(i2c_bus, temp_reading_sender));
 
     // Every 100ms we read for the latest value from the temperature sensor.
     loop {

--- a/boards/stm32f767zi/src/tasks/read_keyence.rs
+++ b/boards/stm32f767zi/src/tasks/read_keyence.rs
@@ -4,6 +4,9 @@ use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, watch::Sender};
 use embassy_time::{Duration, Timer};
 use hyped_sensors::keyence::Keyence;
 
+/// The update frequency of the Keyence sensor in Hz
+const UPDATE_FREQUENCY: u64 = 10;
+
 /// Test task that just continually updates the stripe count from the Keyence sensor (or other GPIO pin input)
 #[embassy_executor::task]
 pub async fn read_keyence(
@@ -15,6 +18,6 @@ pub async fn read_keyence(
     loop {
         keyence.update_stripe_count();
         sender.send(keyence.get_stripe_count());
-        Timer::after(Duration::from_millis(100)).await;
+        Timer::after(Duration::from_hz(UPDATE_FREQUENCY)).await;
     }
 }

--- a/boards/stm32f767zi/src/tasks/read_temperature.rs
+++ b/boards/stm32f767zi/src/tasks/read_temperature.rs
@@ -9,10 +9,14 @@ use embassy_sync::{
     },
     watch::Sender,
 };
+use embassy_time::{Duration, Timer};
 use hyped_sensors::temperature::{Status, Temperature, TemperatureAddresses};
 use hyped_sensors::SensorValueRange;
 
 type I2c1Bus = Mutex<NoopRawMutex, RefCell<I2c<'static, Blocking>>>;
+
+/// The update frequency of the temperature sensor in Hz
+const UPDATE_FREQUENCY: u64 = 1000;
 
 /// Test task that just reads the temperature from the sensor and prints it to the console
 #[embassy_executor::task]
@@ -44,6 +48,7 @@ pub async fn read_temperature(
             Status::Ok => {}
         }
 
-        sender.send(temperature_sensor.read())
+        sender.send(temperature_sensor.read());
+        Timer::after(Duration::from_hz(UPDATE_FREQUENCY)).await;
     }
 }

--- a/boards/stm32l476rg/Cargo.lock
+++ b/boards/stm32l476rg/Cargo.lock
@@ -630,8 +630,8 @@ dependencies = [
 name = "hyped_adc"
 version = "0.1.0"
 dependencies = [
- "embassy-sync 0.6.2",
  "defmt",
+ "embassy-sync 0.6.2",
  "heapless",
 ]
 

--- a/boards/stm32l476rg/src/bin/temperature_test.rs
+++ b/boards/stm32l476rg/src/bin/temperature_test.rs
@@ -37,9 +37,7 @@ async fn main(spawner: Spawner) -> ! {
     let temp_reading_sender = TEMP_READING.sender();
     let mut temp_reading_receiver = TEMP_READING.receiver().unwrap();
 
-    spawner
-        .spawn(read_temperature(i2c_bus, temp_reading_sender))
-        .unwrap();
+    spawner.must_spawn(read_temperature(i2c_bus, temp_reading_sender));
 
     // Every 100ms we read for the latest value from the temperature sensor.
     loop {

--- a/boards/stm32l476rg/src/tasks/read_keyence.rs
+++ b/boards/stm32l476rg/src/tasks/read_keyence.rs
@@ -4,6 +4,9 @@ use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, watch::Sender};
 use embassy_time::{Duration, Timer};
 use hyped_sensors::keyence::Keyence;
 
+/// The update frequency of the Keyence sensor in Hz
+const UPDATE_FREQUENCY: u64 = 10;
+
 /// Test task that just continually updates the stripe count from the Keyence sensor (or other GPIO pin input)
 #[embassy_executor::task]
 pub async fn read_keyence(
@@ -15,6 +18,6 @@ pub async fn read_keyence(
     loop {
         keyence.update_stripe_count();
         sender.send(keyence.get_stripe_count());
-        Timer::after(Duration::from_millis(100)).await;
+        Timer::after(Duration::from_hz(UPDATE_FREQUENCY)).await;
     }
 }

--- a/boards/stm32l476rg/src/tasks/read_temperature.rs
+++ b/boards/stm32l476rg/src/tasks/read_temperature.rs
@@ -9,12 +9,16 @@ use embassy_sync::{
     },
     watch::Sender,
 };
+use embassy_time::{Duration, Timer};
 use hyped_sensors::{
     temperature::{Status, Temperature, TemperatureAddresses},
     SensorValueRange,
 };
 
 type I2c1Bus = Mutex<NoopRawMutex, RefCell<I2c<'static, Blocking>>>;
+
+/// The update frequency of the temperature sensor in Hz
+const UPDATE_FREQUENCY: u64 = 1000;
 
 /// Test task that just reads the temperature from the sensor and prints it to the console
 #[embassy_executor::task]
@@ -46,6 +50,7 @@ pub async fn read_temperature(
             Status::Ok => {}
         }
 
-        sender.send(temperature_sensor.read())
+        sender.send(temperature_sensor.read());
+        Timer::after(Duration::from_hz(UPDATE_FREQUENCY)).await;
     }
 }


### PR DESCRIPTION
Fixes the issue that @Aux1r found when testing a temperature sensor that the current implementation using `Watch` doesn't do anything.

I believe the issue was that the main loop was never being run because the spawned `read_temperature` task never waited inside its loop, resulting in the main loop never being scheduled (or something to that effect). Resolved by adding an `UPDATE_FREQUENCY` to `read_*` tasks to throttle the loop.